### PR TITLE
Put DictCursor in heroku db connection in db.py

### DIFF
--- a/portal/db.py
+++ b/portal/db.py
@@ -14,7 +14,7 @@ def get_db():
         # open a connection, save it to close when done
         DB_URL = os.environ.get('DATABASE_URL', None)
         if DB_URL:
-            g.db = psycopg2.connect(DB_URL, sslmode='require')
+            g.db = psycopg2.connect(DB_URL, sslmode='require', cursor_factory=DictCursor)
         else:
             g.db = psycopg2.connect(
 


### PR DESCRIPTION
Fixed an error where on heroku, the database would return a tuple and not a dictionary like object.